### PR TITLE
use our exception catching mechanisms instead of using celery's exception

### DIFF
--- a/opbeat/contrib/celery/__init__.py
+++ b/opbeat/contrib/celery/__init__.py
@@ -44,7 +44,6 @@ def register_signal(client):
     def process_failure_signal(sender, task_id, exception, args, kwargs,
                                traceback, einfo, **kw):
         client.captureException(
-            exc_info=einfo.exc_info,
             extra={
                 'task_id': task_id,
                 'task': sender,


### PR DESCRIPTION
celery doesn't capture local vars, but we do, so that's nice.
