### PR TITLE
Unify frame order

### DIFF
--- a/opbeat/handlers/logging.py
+++ b/opbeat/handlers/logging.py
@@ -30,10 +30,12 @@ class OpbeatHandler(logging.Handler, object):
             if isinstance(arg, Client):
                 self.client = arg
             else:
-                raise ValueError('The first argument to %s must be a Client instance, got %r instead.' % (
-                    self.__class__.__name__,
-                    arg,
-                ))
+                raise ValueError(
+                    'The first argument to %s must be a Client instance, '
+                    'got %r instead.' % (
+                        self.__class__.__name__,
+                        arg,
+                    ))
         elif 'client' in kwargs:
             self.client = kwargs['client']
         else:
@@ -57,7 +59,10 @@ class OpbeatHandler(logging.Handler, object):
         try:
             return self._emit(record)
         except Exception:
-            six.print_("Top level Opbeat exception caught - failed creating log record", sys.stderr)
+            six.print_(
+                "Top level Opbeat exception caught - "
+                "failed creating log record",
+                sys.stderr)
             six.print_(to_string(record.msg), sys.stderr)
             six.print_(to_string(traceback.format_exc()), sys.stderr)
 
@@ -91,7 +96,9 @@ class OpbeatHandler(logging.Handler, object):
                 if not started:
                     f_globals = getattr(frame, 'f_globals', {})
                     module_name = f_globals.get('__name__', '')
-                    if last_mod.startswith('logging') and not module_name.startswith('logging'):
+                    if last_mod.startswith(
+                            'logging') and not module_name.startswith(
+                            'logging'):
                         started = True
                     else:
                         last_mod = module_name
@@ -100,9 +107,13 @@ class OpbeatHandler(logging.Handler, object):
             stack = frames
 
         extra = getattr(record, 'data', {})
-        # Add in all of the data from the record that we aren't already capturing
+        # Add in all of the data from the record that
+        # we aren't already capturing
         for k in record.__dict__.keys():
-            if k in ('stack', 'name', 'args', 'msg', 'levelno', 'exc_text', 'exc_info', 'data', 'created', 'levelname', 'msecs', 'relativeCreated'):
+            if k in (
+                    'stack', 'name', 'args', 'msg', 'levelno', 'exc_text',
+                    'exc_info', 'data', 'created', 'levelname', 'msecs',
+                    'relativeCreated'):
                 continue
             if k.startswith('_'):
                 continue
@@ -110,7 +121,8 @@ class OpbeatHandler(logging.Handler, object):
 
         date = datetime.datetime.utcfromtimestamp(record.created)
 
-        # If there's no exception being processed, exc_info may be a 3-tuple of None
+        # If there's no exception being processed, exc_info
+        # may be a 3-tuple of None
         # http://docs.python.org/library/sys.html#sys.exc_info
         if record.exc_info and all(record.exc_info):
             handler = self.client.get_handler('opbeat.events.Exception')
@@ -121,6 +133,8 @@ class OpbeatHandler(logging.Handler, object):
         data['level'] = record.levelno
         data['logger'] = record.name
 
-        return self.client.capture('Message', param_message={'message':record.msg,'params':record.args},
-                            stack=stack, data=data, extra=extra,
-                            date=date, **kwargs)
+        return self.client.capture('Message',
+                                   param_message={'message': record.msg,
+                                                  'params': record.args},
+                                   stack=stack, data=data, extra=extra,
+                                   date=date, **kwargs)

--- a/opbeat/handlers/logging.py
+++ b/opbeat/handlers/logging.py
@@ -82,7 +82,7 @@ class OpbeatHandler(logging.Handler, object):
             frames = []
             started = False
             last_mod = ''
-            for item in stack:
+            for item in reversed(list(stack)):
                 if isinstance(item, (list, tuple)):
                     frame, lineno = item
                 else:

--- a/opbeat/handlers/logging.py
+++ b/opbeat/handlers/logging.py
@@ -104,7 +104,7 @@ class OpbeatHandler(logging.Handler, object):
                         last_mod = module_name
                         continue
                 frames.append((frame, lineno))
-            stack = frames
+            stack = reversed(frames)
 
         extra = getattr(record, 'data', {})
         # Add in all of the data from the record that

--- a/opbeat/utils/stacks.py
+++ b/opbeat/utils/stacks.py
@@ -156,6 +156,10 @@ def iter_stack_frames(frames=None):
     """
     if not frames:
         frames = inspect.stack()[1:]
+
+    # Opbeat expects deepest last order
+    frames = reversed(frames)
+
     for frame, lineno in ((f[0], f[2]) for f in frames):
         f_locals = getattr(frame, 'f_locals', {})
         if _getitem_from_frame(f_locals, '__traceback_hide__'):

--- a/opbeat/utils/stacks.py
+++ b/opbeat/utils/stacks.py
@@ -155,10 +155,7 @@ def iter_stack_frames(frames=None):
     local variable.
     """
     if not frames:
-        frames = inspect.stack()[1:]
-
-    # Opbeat expects deepest last order
-    frames = reversed(frames)
+        frames = reversed(inspect.stack()[1:])
 
     for frame, lineno in ((f[0], f[2]) for f in frames):
         f_locals = getattr(frame, 'f_locals', {})

--- a/opbeat/utils/stacks.py
+++ b/opbeat/utils/stacks.py
@@ -177,7 +177,6 @@ def get_stack_info(frames):
     of the information we want.
     """
     results = []
-    # print list(frames)[0]
     for frame, lineno in frames:
         # Support hidden frames
         f_locals = getattr(frame, 'f_locals', {})

--- a/opbeat/version.py
+++ b/opbeat/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.3.2"
+VERSION = "1.3.3"

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -84,7 +84,6 @@ class LoggingIntegrationTest(TestCase):
         self.assertEquals(len(self.client.events), 1)
         event = self.client.events.pop(0)
         # self.assertEquals(event['message'], 'This is a test of args')
-        # print event.keys()
         self.assertFalse('stacktrace' in event)
         self.assertFalse('exception' in event)
         self.assertTrue('param_message' in event)
@@ -99,7 +98,7 @@ class LoggingIntegrationTest(TestCase):
         self.assertTrue('stacktrace' in event)
         frames = event['stacktrace']['frames']
         self.assertNotEquals(len(frames), 1)
-        frame = frames[0]
+        frame = frames[-1]
         self.assertEquals(frame['module'], __name__)
         self.assertFalse('exception' in event)
         self.assertTrue('param_message' in event)
@@ -136,6 +135,10 @@ class LoggingIntegrationTest(TestCase):
         self.assertEquals(msg['message'], 'This is a test of stacks')
         self.assertEquals(msg['params'], ())
         self.assertTrue('stacktrace' in event)
+        frames = event['stacktrace']['frames']
+        self.assertNotEquals(len(frames), 1)
+        frame = frames[-1]
+        self.assertEquals(frame['module'], __name__)
 
     def test_extra_culprit(self):
         self.logger.info('This is a test of stacks', extra={'culprit': 'foo.bar'})


### PR DESCRIPTION
When using the logging handler, frames were ordered with the deepest call first. This reverses the order