### PR TITLE
Only retrieve Django user information if django.contrib.auth is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 - 3.4
 env:
   matrix:
-    - DJANGO=1.3
     - DJANGO=1.4
     - DJANGO=1.5
     - DJANGO=1.6
@@ -25,11 +24,7 @@ matrix:
   - python: 2.6
     env: DJANGO=master
   - python: 3.3
-    env: DJANGO=1.3
-  - python: 3.3
     env: DJANGO=1.4
-  - python: 3.4
-    env: DJANGO=1.3
   - python: 3.4
     env: DJANGO=1.4
   allow_failures:

--- a/opbeat/contrib/django/client.py
+++ b/opbeat/contrib/django/client.py
@@ -13,10 +13,21 @@ from __future__ import absolute_import
 
 import logging
 
-from django.conf import settings
 from django.http import HttpRequest
 from django.template import TemplateSyntaxError
 from django.template.loader import LoaderOrigin
+
+try:
+    # Attempt to use the Django 1.7+ apps sub-framework.
+    from django.apps import apps
+
+    is_app_installed = apps.is_installed
+except ImportError:
+    from django.conf import settings
+
+    # Use the legacy method of simple checking the configuration.
+    def is_app_installed(app_name):
+        return app_name in settings.INSTALLED_APPS
 
 from opbeat.base import Client
 from opbeat.contrib.django.utils import get_data_from_template
@@ -52,8 +63,7 @@ class DjangoClient(Client):
         return user_info
 
     def get_data_from_request(self, request):
-        django_auth_installed = \
-            'django.contrib.auth' in settings.INSTALLED_APPS
+        django_auth_installed = is_app_installed('django.contrib.auth')
 
         if django_auth_installed:
             from django.contrib.auth.models import AnonymousUser

--- a/test_requirements/requirements-django-1.2.txt
+++ b/test_requirements/requirements-django-1.2.txt
@@ -1,2 +1,0 @@
-Django>=1.2.7,<1.3
--r requirements-base.txt

--- a/test_requirements/requirements-django-1.3.txt
+++ b/test_requirements/requirements-django-1.3.txt
@@ -1,2 +1,0 @@
-Django>=1.3.7,<1.4
--r requirements-base.txt

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -218,10 +218,13 @@ class DjangoClientTest(TestCase):
             self.assertFalse('email' in user_info)
 
     def test_user_info_with_non_django_auth(self):
-        with self.settings(INSTALLED_APPS=[
-                app for app in settings.INSTALLED_APPS if app != 'django.contrib.auth'
+        with Settings(INSTALLED_APPS=[
+            app for app in settings.INSTALLED_APPS
+            if app != 'django.contrib.auth'
         ]):
-            self.assertRaises(Exception, self.client.get, reverse('opbeat-raise-exc'))
+            self.assertRaises(Exception,
+                              self.client.get,
+                              reverse('opbeat-raise-exc'))
 
             self.assertEquals(len(self.opbeat.events), 1)
             event = self.opbeat.events.pop(0)

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -217,6 +217,16 @@ class DjangoClientTest(TestCase):
             self.assertEquals(user_info['username'], 'admin')
             self.assertFalse('email' in user_info)
 
+    def test_user_info_with_non_django_auth(self):
+        with self.settings(INSTALLED_APPS=[
+                app for app in settings.INSTALLED_APPS if app != 'django.contrib.auth'
+        ]):
+            self.assertRaises(Exception, self.client.get, reverse('opbeat-raise-exc'))
+
+            self.assertEquals(len(self.opbeat.events), 1)
+            event = self.opbeat.events.pop(0)
+            self.assertFalse('user' in event)
+
     def test_request_middleware_exception(self):
         with Settings(MIDDLEWARE_CLASSES=['tests.contrib.django.middleware.BrokenRequestMiddleware']):
             self.assertRaises(ImportError, self.client.get, reverse('opbeat-raise-exc'))


### PR DESCRIPTION
Due to the legacy of pre-1.5 Django not supporting custom user models, we do not rely on `django.contrib.auth` but rather an internal module, which causes problems in error reporting. This should fix the issue by only relying on `django.contrib.auth` when it is actually installed.