### PR TITLE
Debug support for Flask and refactor of `disabled_due_to_debug`

### DIFF
--- a/opbeat/contrib/django/middleware/__init__.py
+++ b/opbeat/contrib/django/middleware/__init__.py
@@ -65,8 +65,8 @@ class OpbeatAPMMiddleware(object):
 
     def process_request(self, request):
         if disabled_due_to_debug(
-                getattr(django_settings, 'OPBEAT', {}),
-                getattr(django_settings, 'OPBEAT', {}).get('DEBUG', False)
+            getattr(django_settings, 'OPBEAT', {}),
+            getattr(django_settings, 'OPBEAT', {}).get('DEBUG', False)
         ):
             return
 

--- a/opbeat/contrib/django/middleware/__init__.py
+++ b/opbeat/contrib/django/middleware/__init__.py
@@ -14,17 +14,17 @@ import time
 import logging
 import threading
 
-from django.conf import settings
+from django.conf import settings as django_settings
 
 from opbeat.contrib.django.models import client, get_client
-from opbeat.contrib.django.utils import disabled_due_to_debug
+from opbeat.utils import disabled_due_to_debug
 
 
 def _is_ignorable_404(uri):
     """
     Returns True if the given request *shouldn't* notify the site managers.
     """
-    urls = getattr(settings, 'IGNORABLE_404_URLS', ())
+    urls = getattr(django_settings, 'IGNORABLE_404_URLS', ())
     return any(pattern.search(uri) for pattern in urls)
 
 
@@ -64,8 +64,13 @@ class OpbeatAPMMiddleware(object):
         return "{0}.{1}".format(module, view_name)
 
     def process_request(self, request):
-        if not disabled_due_to_debug():
-            self.thread_local.request_start = time.time()
+        if disabled_due_to_debug(
+                getattr(django_settings, 'OPBEAT', {}),
+                getattr(django_settings, 'OPBEAT', {}).get('DEBUG', False)
+        ):
+            return
+
+        self.thread_local.request_start = time.time()
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         self.thread_local.view_func = view_func

--- a/opbeat/contrib/django/models.py
+++ b/opbeat/contrib/django/models.py
@@ -16,9 +16,8 @@ from __future__ import absolute_import
 import sys
 import logging
 import warnings
-from opbeat.contrib.django.utils import disabled_due_to_debug
 from opbeat.utils import six
-
+from opbeat.utils import disabled_due_to_debug
 from django.conf import settings as django_settings
 
 
@@ -145,8 +144,13 @@ def opbeat_exception_handler(request=None, **kwargs):
     def actually_do_stuff(request=None, **kwargs):
         exc_info = sys.exc_info()
         try:
-            if (disabled_due_to_debug()
-                    or getattr(exc_info[1], 'skip_opbeat', False)):
+            if (
+                disabled_due_to_debug(
+                    getattr(django_settings, 'OPBEAT', {}),
+                    getattr(django_settings, 'OPBEAT', {}).get('DEBUG', False)
+                )
+                or getattr(exc_info[1], 'skip_opbeat', False)
+            ):
                 return
 
             get_client().capture('Exception', exc_info=exc_info,

--- a/opbeat/contrib/django/utils.py
+++ b/opbeat/contrib/django/utils.py
@@ -1,6 +1,3 @@
-from django.conf import settings as django_settings
-
-
 def linebreak_iter(template_source):
     yield 0
     p = template_source.find('\n')
@@ -41,8 +38,3 @@ def get_data_from_template(source):
         },
         'culprit': origin.loadname,
     }
-
-
-def disabled_due_to_debug():
-    config = getattr(django_settings, 'OPBEAT', {})
-    return django_settings.DEBUG and not config.get('DEBUG', False)

--- a/opbeat/contrib/flask/__init__.py
+++ b/opbeat/contrib/flask/__init__.py
@@ -132,8 +132,8 @@ class Opbeat(object):
             return
 
         if disabled_due_to_debug(
-                self.app.config.get('OPBEAT', {}),
-                self.app.config.get('DEBUG', False)
+            self.app.config.get('OPBEAT', {}),
+            self.app.config.get('DEBUG', False)
         ):
             return
 

--- a/opbeat/contrib/flask/__init__.py
+++ b/opbeat/contrib/flask/__init__.py
@@ -19,6 +19,7 @@ from flask.signals import got_request_exception
 from opbeat.conf import setup_logging
 from opbeat.base import Client
 from opbeat.contrib.flask.utils import get_data_from_request
+from opbeat.utils import disabled_due_to_debug
 from opbeat.handlers.logging import OpbeatHandler
 
 
@@ -128,6 +129,12 @@ class Opbeat(object):
 
     def handle_exception(self, *args, **kwargs):
         if not self.client:
+            return
+
+        if disabled_due_to_debug(
+                self.app.config.get('OPBEAT', {}),
+                self.app.config.get('DEBUG', False)
+        ):
             return
 
         self.client.capture('Exception', exc_info=kwargs.get('exc_info'),

--- a/opbeat/utils/__init__.py
+++ b/opbeat/utils/__init__.py
@@ -32,3 +32,11 @@ def varmap(func, var, context=None, name=None):
     del context[objid]
     return ret
 
+def disabled_due_to_debug(opbeat_config, debug):
+    """
+    Compares configs to determine whether to log to Opbeat
+    :param opbeat_config:
+    :param debug:
+    :return: boolean
+    """
+    return debug and not opbeat_config.get('DEBUG', False)

--- a/opbeat/utils/__init__.py
+++ b/opbeat/utils/__init__.py
@@ -2,7 +2,7 @@
 opbeat.utils
 ~~~~~~~~~~~~~~~~~~~
 
-:copyright: (c) 2011-2012 Opbeat
+:copyright: (c) 2011-2015 Opbeat
 
 Large portions are
 :copyright: (c) 2010 by the Sentry Team, see AUTHORS for more details.
@@ -34,9 +34,9 @@ def varmap(func, var, context=None, name=None):
 
 def disabled_due_to_debug(opbeat_config, debug):
     """
-    Compares configs to determine whether to log to Opbeat
-    :param opbeat_config: Dictionary containing Opbeat settings
-    :param debug: Boolean denoting Django DEBUG state
-    :return: Boolean True if it should not log
+    Compares module and app configs to determine whether to log to Opbeat
+    :param opbeat_config: Dictionary containing module config
+    :param debug: Boolean denoting app DEBUG state
+    :return: Boolean True if logging is disabled
     """
     return debug and not opbeat_config.get('DEBUG', False)

--- a/opbeat/utils/__init__.py
+++ b/opbeat/utils/__init__.py
@@ -35,8 +35,8 @@ def varmap(func, var, context=None, name=None):
 def disabled_due_to_debug(opbeat_config, debug):
     """
     Compares configs to determine whether to log to Opbeat
-    :param opbeat_config:
-    :param debug:
-    :return: boolean
+    :param opbeat_config: Dictionary containing Opbeat settings
+    :param debug: Boolean denoting Django DEBUG state
+    :return: Boolean True if it should not log
     """
     return debug and not opbeat_config.get('DEBUG', False)


### PR DESCRIPTION
I wanted to make the Opbeat module respect Flask environments (Debug = True/False) and also ended up refactoring `disabled_due_to_debug` a bit so it became reusable.

Note: 
I am very much a Python newbie, so bear with any silly mistakes.
Tested with a starter-kit/dummy Flask app.
