### PR TITLE
Updated the template loader import for Django 1.9 compatibility

### DIFF
--- a/opbeat/contrib/django/client.py
+++ b/opbeat/contrib/django/client.py
@@ -16,7 +16,10 @@ import logging
 from django.db import DatabaseError
 from django.http import HttpRequest
 from django.template import TemplateSyntaxError
-from django.template.loader import LoaderOrigin
+try:
+    from django.template.loader import LoaderOrigin  # Django < 1.9
+except ImportError:
+    from django.template.base import Origin as LoaderOrigin  # Django >= 1.9
 
 try:
     # Attempt to use the Django 1.7+ apps sub-framework.


### PR DESCRIPTION
This fixes #69 -- at least, the one error I've seen so far. I haven't been able to test for full compatibility yet.