### PR TITLE
don't use djcelery for Django 1.8+

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,13 @@ collect_ignore = ['build', 'src']
 
 def pytest_configure(config):
     if not settings.configured:
+        import django
+
+        # django-celery does not work well with Django 1.8+
+        if django.VERSION < (1, 8):
+            djcelery = ['djcelery']
+        else:
+            djcelery = []
         settings.configure(
             DATABASE_ENGINE='sqlite3',
             DATABASES={
@@ -39,11 +46,9 @@ def pytest_configure(config):
 
                 'django.contrib.contenttypes',
 
-                'djcelery',  # celery client
-
                 'opbeat.contrib.django',
                 'tests.contrib.django.testapp',
-            ],
+            ] + djcelery,
             ROOT_URLCONF='tests.contrib.django.testapp.urls',
             DEBUG=False,
             SITE_ID=1,
@@ -62,8 +67,8 @@ def pytest_configure(config):
                 'django.contrib.messages.middleware.MessageMiddleware',
             ],
         )
-        import django
         if hasattr(django, 'setup'):
             django.setup()
-        import djcelery
-        djcelery.setup_loader()
+        if django.VERSION < (1, 8):
+            import djcelery
+            djcelery.setup_loader()

--- a/tests/contrib/django/testapp/__init__.py
+++ b/tests/contrib/django/testapp/__init__.py
@@ -1,2 +1,5 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
+from .celery import app as celery_app

--- a/tests/contrib/django/testapp/celery.py
+++ b/tests/contrib/django/testapp/celery.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from celery import Celery
+
+from django.conf import settings
+
+app = Celery('testapp')
+
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+# hook up Opbeat
+
+from opbeat.contrib.django.models import client, logger, register_handlers
+from opbeat.contrib.celery import register_signal
+
+try:
+    register_signal(client)
+except Exception as e:
+    logger.exception('Failed installing celery hook: %s' % e)
+
+if 'opbeat.contrib.django' in settings.INSTALLED_APPS:
+    register_handlers()


### PR DESCRIPTION
it looks like django-celery isn't kept up to date with Django anymore, and we
don't use its functionality anyway

https://github.com/celery/django-celery/issues/391
https://github.com/celery/django-celery/pull/356