### PR TITLE
sanitizer handle non utf8 request data

### DIFF
--- a/opbeat/processors.py
+++ b/opbeat/processors.py
@@ -101,7 +101,7 @@ class SanitizePasswordsProcessor(Processor):
                 continue
 
             if isinstance(data[n], (six.binary_type,) + six.string_types):
-                text_data = force_text(data[n])
+                text_data = force_text(data[n], errors='replace')
                 if '=' in text_data:
                     # at this point we've assumed it's a standard HTTP query
                     querybits = []

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -139,6 +139,16 @@ class SantizePasswordsProcessorTest(TestCase):
         result = proc.sanitize('foo', '4242424242424242')
         self.assertEquals(result, proc.MASK)
 
+    def test_non_utf8_encoding(self):
+        data = {
+            'http': {
+                'query_string': six.b('broken=') + u"aéöüa".encode('latin-1')
+            }
+        }
+        proc = SanitizePasswordsProcessor(Mock())
+        result = proc.process(data)
+        assert result['http']['query_string'] == u'broken=a\ufffd\ufffd\ufffda'
+
 
 class RemovePostDataProcessorTest(TestCase):
     def test_does_remove_data(self):


### PR DESCRIPTION
This ensures that we don't completely break when the request has non-utf8
data in its request data