### PR TITLE
ensure that token is not None before accessing its attributes

### DIFF
--- a/opbeat/contrib/django/utils.py
+++ b/opbeat/contrib/django/utils.py
@@ -87,7 +87,7 @@ def iterate_with_template_sources(frames, extended=True):
             if function == 'render':
                 renderer = getattr(frame, 'f_locals', {}).get('self')
                 if renderer and isinstance(renderer, Node):
-                    if hasattr(renderer, "token"):
+                    if getattr(renderer, "token", None) is not None:
                         if hasattr(renderer, "source"):
                             # up to Django 1.8
                             yield {


### PR DESCRIPTION
Despite what my reading of https://github.com/django/django/blob/62e83c71d2086b91d58c313e46933ef7aa8b6db1/django/template/base.py#L463
says, several bug reports and support tickets indicate that there can indeed be
nodes without tokens. All reported issues seem to involve nodes that invoke
template rendering (either through calling render_to_string in their render
method, or inclusion tags.

I wasn't able to reproduce the actual error yet, hence the unfortunate lack of
tests.