### PR TITLE
Add support for asyncio compatible transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ install:
 - pip install -U pip
 - pip install -r test_requirements/requirements-$WEBFRAMEWORK.txt --cache-dir $PIP_CACHE
 - pip install -r test_requirements/requirements-python-$(python --version 2>&1 | awk -F'[ |.]' 'NR==1{ print $2 }').txt --cache-dir $PIP_CACHE
+- if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install -r test_requirements/requirements-asyncio.txt --cache-dir $PIP_CACHE; fi
 - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install -r test_requirements/requirements-cpython.txt --cache-dir $PIP_CACHE; fi
 - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install -r test_requirements/requirements-pypy.txt --cache-dir $PIP_CACHE; fi
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ isort:
 	isort -rc -vb .
 
 test:
-	py.test --isort
+	if [ "$$TRAVIS_PYTHON_VERSION" != "3.5" ]; then \
+	py.test --isort --ignore=tests/asyncio; \
+	else py.test --isort; fi
 
 coverage:
 	coverage run runtests.py --include=opbeat/* && \

--- a/opbeat/contrib/asyncio/__init__.py
+++ b/opbeat/contrib/asyncio/__init__.py
@@ -1,0 +1,1 @@
+from .client import Client

--- a/opbeat/contrib/asyncio/client.py
+++ b/opbeat/contrib/asyncio/client.py
@@ -1,0 +1,25 @@
+import asyncio
+import urllib.parse
+
+from opbeat.base import Client
+
+
+class Client(Client):
+
+    def handle_transport_response(self, task):
+        try:
+            url = task.result()
+        except Exception as exc:
+            self.handle_transport_fail(exception=exc)
+        else:
+            self.handle_transport_success(url=url)
+
+    def _send_remote(self, url, data, headers=None):
+        if headers is None:
+            headers = {}
+        parsed = urllib.parse.urlparse(url)
+        transport = self._get_transport(parsed)
+        loop = asyncio.get_event_loop()
+        task = loop.create_task(
+            transport.send(data, headers, timeout=self.timeout))
+        task.add_done_callback(self.handle_transport_response)

--- a/opbeat/handlers/logging.py
+++ b/opbeat/handlers/logging.py
@@ -24,9 +24,10 @@ from opbeat.utils.stacks import iter_stack_frames
 
 class OpbeatHandler(logging.Handler, object):
     def __init__(self, *args, **kwargs):
-        client = kwargs.get('client_cls', Client)
+        client = kwargs.pop('client_cls', Client)
         if len(args) == 1:
             arg = args[0]
+            args = args[1:]
             if isinstance(arg, Client):
                 self.client = arg
             else:
@@ -37,11 +38,11 @@ class OpbeatHandler(logging.Handler, object):
                         arg,
                     ))
         elif 'client' in kwargs:
-            self.client = kwargs['client']
+            self.client = kwargs.pop('client')
         else:
             self.client = client(*args, **kwargs)
 
-        logging.Handler.__init__(self)
+        super(OpbeatHandler, self).__init__(*args, **kwargs)
 
     def emit(self, record):
         self.format(record)

--- a/opbeat/transport/asyncio.py
+++ b/opbeat/transport/asyncio.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import aiohttp
+
+from .base import TransportException
+from .http import HTTPTransport
+
+
+class AsyncioHTTPTransport(HTTPTransport):
+    """
+    HTTP Transport ready for asyncio
+    """
+
+    def __init__(self, parsed_url):
+        self.check_scheme(parsed_url)
+
+        self._parsed_url = parsed_url
+        self._url = parsed_url.geturl()
+        loop = asyncio.get_event_loop()
+        self.client = aiohttp.ClientSession(loop=loop)
+
+    async def send(self, data, headers, timeout=None):
+        """Use synchronous interface, because this is a coroutine."""
+
+        if timeout is None:
+            timeout = defaults.TIMEOUT
+        try:
+            with aiohttp.Timeout(timeout):
+                async with self.client.post(self._url,
+                                            data=data,
+                                            headers=headers) as response:
+                    assert response.status == 202
+        except asyncio.TimeoutError as e:
+            print_trace = True
+            message = ("Connection to Opbeat server timed out "
+                       "(url: %s, timeout: %d seconds)" % (self._url, timeout))
+            raise TransportException(message, data,
+                                     print_trace=print_trace) from e
+        except AssertionError as e:
+            print_trace = True
+            body = await response.read()
+            if response.status == 429:
+                message = 'Temporarily rate limited: '
+                print_trace = False
+            else:
+                message = 'Unable to reach Opbeat server: '
+            message += '%s (url: %s, body: %s)' % (e, self._url, body)
+            raise TransportException(message, data,
+                                     print_trace=print_trace) from e
+        except Exception as e:
+            message = 'Unable to reach Opbeat server: %s (url: %s)' % (
+                e, self._url)
+            raise TransportException(message, data,
+                                     print_trace=print_trace) from e
+        else:
+            return response.headers['Location']
+
+    def __del__(self):
+        self.client.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,9 @@ universal=0
 
 [pytest]
 python_files=tests.py test_*.py *_tests.py
+isort_ignore=
+    opbeat/transport/asyncio.py
+    opbeat/contrib/asyncio/client.py
 
 [isort]
 line_length=80

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,12 @@ except ImportError:
         tests_require += ['zerorpc>=0.4.0,<0.5']
     tests_require += ['psycopg2']
 
+if sys.version_info >= (3, 5):
+    tests_require += [
+        'aiohttp',
+        'pytest-asyncio',
+        'pytest-mock',
+    ]
 
 install_requires = []
 
@@ -117,6 +123,11 @@ except ImportError:
 
 
 class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -126,7 +137,7 @@ class PyTest(TestCommand):
     def run_tests(self):
         #import here, cause outside the eggs aren't loaded
         import pytest
-        errno = pytest.main(self.test_args)
+        errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
 
@@ -142,7 +153,9 @@ setup_kwargs = dict(
     zip_safe=False,
     install_requires=install_requires,
     tests_require=tests_require,
-    extras_require={'tests': tests_require, 'flask': ['blinker']},
+    extras_require={'tests': tests_require,
+                    'flask': ['blinker'],
+                    'asyncio': ['aiohttp']},
     cmdclass={'test': PyTest},
     test_suite='tests',
     include_package_data=True,

--- a/test_requirements/requirements-asyncio.txt
+++ b/test_requirements/requirements-asyncio.txt
@@ -1,0 +1,3 @@
+aiohttp
+pytest-asyncio
+pytest-mock

--- a/tests/asyncio/test_asyncio_client.py
+++ b/tests/asyncio/test_asyncio_client.py
@@ -1,0 +1,67 @@
+import asyncio
+import sys
+from urllib.parse import urlparse
+
+import mock
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.version_info < (3, 5),
+                                reason='python3.5+ requried for asyncio')
+
+
+class MockTransport(mock.MagicMock):
+
+    def __init__(self, url=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.url = url
+
+    async def send(self, data, headers, timeout):
+        from opbeat.transport.base import TransportException
+        self.data = data
+        if self.url == urlparse('http://error'):
+            raise TransportException('', data, False)
+        await asyncio.sleep(0.0001)
+
+
+@pytest.mark.asyncio
+async def test_client_success():
+    from opbeat.contrib.asyncio import Client
+
+    client = Client(
+        servers=['http://localhost'],
+        organization_id='organization_id',
+        app_id='app_id',
+        secret_token='secret',
+        async_mode=False,
+        transport_class='.'.join(
+            (__name__, MockTransport.__name__)),
+    )
+    client.send(foo='bar')
+    tasks = asyncio.Task.all_tasks()
+    task = next(t for t in tasks if t is not asyncio.Task.current_task())
+    await task
+    assert client.state.status == 1
+    transport = client._get_transport(urlparse('http://localhost'))
+    assert transport.data == client.encode({'foo': 'bar'})
+
+
+@pytest.mark.asyncio
+async def test_client_failure():
+    from opbeat.contrib.asyncio import Client
+    from opbeat.transport.base import TransportException
+
+    client = Client(
+        servers=['http://error'],
+        organization_id='organization_id',
+        app_id='app_id',
+        secret_token='secret',
+        async_mode=False,
+        transport_class='.'.join(
+            (__name__, MockTransport.__name__)),
+    )
+    client.send(foo='bar')
+    tasks = asyncio.Task.all_tasks()
+    task = next(t for t in tasks if t is not asyncio.Task.current_task())
+    with pytest.raises(TransportException):
+        await task
+    assert client.state.status == 0

--- a/tests/asyncio/test_asyncio_http.py
+++ b/tests/asyncio/test_asyncio_http.py
@@ -1,0 +1,88 @@
+import asyncio
+import sys
+from urllib.parse import urlparse
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.version_info < (3, 5),
+                                reason='python3.5+ requried for asyncio')
+
+@pytest.fixture
+def mock_client(mocker):
+    mock_client = mocker.MagicMock()
+    mock_client.timeout = None
+    response = mocker.MagicMock()
+
+    async def read():
+        return mock_client.body
+
+    response.read = read
+
+
+    class fake_post:
+        async def __aenter__(self, *args, **kwargs):
+            response.status = mock_client.status
+            response.headers = mock_client.headers
+            if mock_client.timeout:
+                await asyncio.sleep(mock_client.timeout)
+            return response
+
+        async def __aexit__(self, *args):
+            pass
+
+        def __init__(self, *args, **kwargs):
+            mock_client.args = args
+            mock_client.kwargs = kwargs
+
+
+    mock_client.post = mocker.Mock(side_effect=fake_post)
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_send(mock_client):
+    from opbeat.transport.asyncio import AsyncioHTTPTransport
+    transport = AsyncioHTTPTransport(urlparse('http://localhost:9999'))
+
+    mock_client.status = 202
+    mock_client.headers = {'Location': 'http://example.com/foo'}
+    transport.client = mock_client
+
+    url = await transport.send(b'data', {'a': 'b'}, timeout=2)
+    assert url == 'http://example.com/foo'
+    assert mock_client.args == ('http://localhost:9999',)
+    assert mock_client.kwargs == {'headers': {'a': 'b'},
+                                  'data': b'data'}
+
+
+@pytest.mark.asyncio
+async def test_send_not_found(mock_client):
+    from opbeat.transport.asyncio import AsyncioHTTPTransport
+    from opbeat.transport.base import TransportException
+
+    transport = AsyncioHTTPTransport(urlparse('http://localhost:9999'))
+
+    mock_client.status = 404
+    mock_client.headers = {}
+    mock_client.body = b'Not Found'
+    transport.client = mock_client
+
+    with pytest.raises(TransportException) as excinfo:
+        await transport.send(b'data', {}, timeout=2)
+    assert 'Not Found' in str(excinfo.value)
+    assert excinfo.value.data == b'data'
+
+
+@pytest.mark.asyncio
+async def test_send_timeout(mock_client):
+    from opbeat.transport.asyncio import AsyncioHTTPTransport
+    from opbeat.transport.base import TransportException
+
+    transport = AsyncioHTTPTransport(urlparse('http://localhost:9999'))
+
+    mock_client.timeout = 0.1
+    transport.client = mock_client
+
+    with pytest.raises(TransportException) as excinfo:
+        await transport.send(b'data', {}, timeout=0.0001)
+    assert 'Connection to Opbeat server timed out' in str(excinfo.value)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py{26,27,33,34,35,py}
 
 [testenv]
-commands = python setup.py test
+commands = python setup.py test -a "{posargs}"


### PR DESCRIPTION
## To install
```bash
pip install opbeat[asyncio]
```

## Usage

```python
from opbeat.contrib.asyncio import Client
from opbeat.handlers.logging import OpbeatHandler

opbeat_client = Client(
    app_id=app_id,
    organization_id=organization_id,
    secret_token=secret_token,
    transport_class='opbeat.transport.asyncio.AsyncioHTTPTransport')

opbeat_handler = OpbeatHandler(opbeat_client, level='ERROR')
logging.getLogger(__name__).addHandler(opbeat_handler)
```