### PR TITLE
make sure we use the non-threaded sync transport if we are in the uwsgi master process

### DIFF
--- a/opbeat/base.py
+++ b/opbeat/base.py
@@ -416,9 +416,11 @@ class Client(object):
         return message
 
     def _get_transport(self, parsed_url):
-        if is_master_process():
+        if self.async_mode and is_master_process():
             # when in the master process, always use SYNC mode. This avoids
             # the danger of being forked into an inconsistent threading state
+            self.logger.info('Sending message synchronously while in master '
+                             'process. PID: %s', os.getpid())
             return HTTPTransport(parsed_url)
         if parsed_url not in self._transports:
             self._transports[parsed_url] = self._transport_class(parsed_url)

--- a/opbeat/utils/__init__.py
+++ b/opbeat/utils/__init__.py
@@ -8,6 +8,7 @@ Large portions are
 :copyright: (c) 2010 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
+import os
 
 from opbeat.utils import six
 
@@ -68,3 +69,12 @@ def build_name_with_http_method_prefix(name, request):
         return request.method + " " + name
     else:
         return name  # 404
+
+
+def is_master_process():
+    # currently only recognizes uwsgi master process
+    try:
+        import uwsgi
+        return os.getpid() == uwsgi.masterpid()
+    except ImportError:
+        return False


### PR DESCRIPTION
This steps around the issue reported in #103. Unfortunately, the `postfork` signal turned
out to be somewhat unreliable in our case, because often (but not always) it was only
installed _after_ uwsgi already forked, leaving us in a bad state.