### PR TITLE
Templatetag for Django to enable JavaScript error-handling

### DIFF
--- a/opbeat/contrib/django/templates/opbeat/javascript_module.html
+++ b/opbeat/contrib/django/templates/opbeat/javascript_module.html
@@ -1,5 +1,5 @@
 {% if ORGANIZATION_ID %}
-    <script src="https://d3tvtfb6518e3e.cloudfront.net/1/opbeat.min.js"
+    <script src="https://d3tvtfb6518e3e.cloudfront.net/3/opbeat.min.js"
             data-org-id="{{ ORGANIZATION_ID }}"
             data-app-id="{{ APP_ID }}"
             {% if ASYNC %}async{% endif %}>

--- a/opbeat/contrib/django/templates/opbeat/javascript_module.html
+++ b/opbeat/contrib/django/templates/opbeat/javascript_module.html
@@ -1,0 +1,24 @@
+{% if ORGANIZATION_ID %}
+    <script src="https://d3tvtfb6518e3e.cloudfront.net/1/opbeat.min.js"
+            data-org-id="{{ ORGANIZATION_ID }}"
+            data-app-id="{{ APP_ID }}"
+            {% if ASYNC %}async{% endif %}>
+    </script>
+    <script type="text/javascript">
+        _opbeat = window._opbeat || function() {
+            (window._opbeat.q = window._opbeat.q || []).push(arguments)
+        };
+        _opbeat('setUserContext', {
+            {% for field, value in user_context.items %}
+                {{ field }}: {{ value }},
+            {% endfor %}
+        });
+        {% if extra_context %}
+            _opbeat('setExtraContext', {
+                {% for field, value in extra_context.items %}
+                    {{ field }}: {{ value }},
+                {% endfor %}
+            });
+        {% endif %}
+    </script>
+{% endif %}

--- a/opbeat/contrib/django/templatetags/opbeat.py
+++ b/opbeat/contrib/django/templatetags/opbeat.py
@@ -1,0 +1,56 @@
+import logging
+
+from django import template
+from django.conf import settings
+from django.utils.safestring import mark_safe
+
+logger = logging.getLogger(__name__)
+register = template.Library()
+
+
+@register.inclusion_tag('opbeat/javascript_module.html', takes_context=True)
+def opbeat_javascript(context, async=True, **kwargs):
+    """
+    Renders the HTML for Opbeat's JavaScript module.
+    """
+
+    def convert_to_js(value):
+        """ Make a value friendly for use in JavaScript, e.g. True -> true """
+
+        if type(value) is bool:
+            return "true" if value else "false"
+
+        return mark_safe('"' + str(value) + '"')
+
+    request = context.get('request')
+
+    try:
+        template_context = {
+            'ORGANIZATION_ID': settings.OPBEAT['ORGANIZATION_ID'],
+            'APP_ID': settings.OPBEAT['JAVASCRIPT_APP_ID'],
+            'ASYNC': async
+        }
+    except (AttributeError, KeyError):
+        logger.exception("Configuration error for Opbeat JavaScript module")
+        return {}
+
+    if request:
+        template_context['user_context'] = user_context = {}
+        is_authenticated = request.user.is_authenticated()
+
+        if is_authenticated:
+            user_context.update({
+                'id': convert_to_js(request.user.id),
+                'username': convert_to_js(request.user.username),
+                'email': convert_to_js(request.user.email)
+            })
+
+        user_context['is_authenticated'] = convert_to_js(is_authenticated)
+
+    if kwargs:
+        template_context['extra_context'] = extra_context = {}
+
+        for extra in kwargs:
+            extra_context[extra] = convert_to_js(kwargs[extra])
+
+    return template_context

--- a/opbeat/contrib/django/templatetags/opbeat.py
+++ b/opbeat/contrib/django/templatetags/opbeat.py
@@ -20,7 +20,7 @@ def opbeat_javascript(context, async=True, **kwargs):
         if type(value) is bool:
             return "true" if value else "false"
 
-        return mark_safe('"' + str(value) + '"')
+        return mark_safe(u'"{}"'.format(value))
 
     request = context.get('request')
 


### PR DESCRIPTION
This is a nice little helper templatetag for Django to easily insert the necessary HTML for JavaScript error-handling from Opbeat into a template.

Usage:

```
{% load opbeat %}

<head>
    {% opbeat_javascript %}
</head>
```

It automatically populates the user context, and allows easy use of the extra context:

```
{% opbeat_javascript is_staff=request.user.is_staff %}
```

Finally, it also makes it easy to enable or disable async mode (on by default):

```
{% opbeat_javascript async=False %}
```

The only additional configuration needed is to add `JAVASCRIPT_APP_ID` to the Opbeat configuration dict, since the app ID is not the same as for the Python code. An error is logged if the templatetag is used and the configuration is improper, and nothing is outputted to the template in that case.

Currently has the CDN version of the Opbeat JS file hardcoded, but this could easily be made configurable as well and added to the Opbeat configuration dict.

Thoughts?
