### PR TITLE
Add support for building manylinux1 binary wheels on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ deploy:
     secure: bixGjrReBq8ET47kpaZQNrBG9EFi6zNi8v6kL/10BQcEkC1YrBwbv1YyjHKZt2joB77QXpQlgEFkjfeR5uX7rjaK7Hp9Cu1l4zr+d2Rl6Q/P4BN346IPImdOjL8EF5aVTOFrSGLvrcFhTZ76IWoLpjgGubqCSw2k6S/+whysAhs=
   skip_cleanup: true
   file_glob: true
-  file: wheelhouse/*.whl
+  file: wheelhouse/opbeat*manylinux*.whl
   on:
     repo: opbeat/opbeat_python
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ env:
     - WEBFRAMEWORK=django-master
     - WEBFRAMEWORK=flask-0.10
   global:
-    - PIP_CACHE="$HOME/.pip_cache"'
-    - RUN_SCRIPT="./travis/run_tests.sh"
-
+  - PIP_CACHE="$HOME/.pip_cache"'
+  - RUN_SCRIPT="./travis/run_tests.sh"
 matrix:
   exclude:
   - python: 2.6
@@ -57,29 +56,46 @@ matrix:
     env: WEBFRAMEWORK=django-1.6
   - python: nightly
     env: WEBFRAMEWORK=django-1.7
+  include:
+  - sudo: required
+    python: 3.4
+    services:
+    - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 RUN_SCRIPT=./travis/run_docker.sh
+  - sudo: required
+    python: 3.4
+    services:
+    - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686 RUN_SCRIPT=./travis/run_docker.sh
+      PRE_CMD=linux32
   allow_failures:
   - env: WEBFRAMEWORK=django-master
   - python: nightly
-
 addons:
   apt:
     packages:
-      - libevent-dev
-      - libzmq3-dev
-  postgresql: "9.3"
-
+    - libevent-dev
+    - libzmq3-dev
+  postgresql: '9.3'
 cache:
   directories:
-    - $HOME/.pip_cache
-
+  - "$HOME/.pip_cache"
 script:
 - bash $RUN_SCRIPT
-
 notifications:
   email: false
   slack:
     secure: LcTTbTj0Px0/9Bs/S/uwbhkdULlj1YVdHnU8F/kOa3bq2QdCTptqB719r6BnzHvW+QGyADvDZ25UncVXFuLuHY67ZYfmyZ/H2cj0nrRSuYdPct0avhVbT/3s50GlNWK5qkfZDuqw6szYTFrgFWJcr5dl7Zf6Vovcvd38uaYOdno=
-
 services:
-  - redis-server
-  - memcached
+- redis-server
+- memcached
+deploy:
+  provider: releases
+  api_key:
+    secure: bixGjrReBq8ET47kpaZQNrBG9EFi6zNi8v6kL/10BQcEkC1YrBwbv1YyjHKZt2joB77QXpQlgEFkjfeR5uX7rjaK7Hp9Cu1l4zr+d2Rl6Q/P4BN346IPImdOjL8EF5aVTOFrSGLvrcFhTZ76IWoLpjgGubqCSw2k6S/+whysAhs=
+  skip_cleanup: true
+  file_glob: true
+  file: wheelhouse/*.whl
+  on:
+    repo: opbeat/opbeat_python
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - WEBFRAMEWORK=flask-0.10
   global:
     - PIP_CACHE="$HOME/.pip_cache"'
+    - RUN_SCRIPT="./travis/run_tests.sh"
 
 matrix:
   exclude:
@@ -71,22 +72,8 @@ cache:
   directories:
     - $HOME/.pip_cache
 
-before_install:
-  - mkdir -p $PIP_CACHE
-
-install:
-- pip install -U pip
-- pip install -r test_requirements/requirements-$WEBFRAMEWORK.txt --cache-dir $PIP_CACHE
-- pip install -r test_requirements/requirements-python-$(python --version 2>&1 | awk -F'[ |.]' 'NR==1{ print $2 }').txt --cache-dir $PIP_CACHE
-- if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install -r test_requirements/requirements-asyncio.txt --cache-dir $PIP_CACHE; fi
-- if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install -r test_requirements/requirements-cpython.txt --cache-dir $PIP_CACHE; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install -r test_requirements/requirements-pypy.txt --cache-dir $PIP_CACHE; fi
-
-before_script:
-  - psql -c 'create database opbeat_test;' -U postgres
-
 script:
-- make test
+- bash $RUN_SCRIPT
 
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ else:
 try:
     import __pypy__
 except ImportError:
-    if sys.version_info[0] == 2:
+    if sys.version_info[0] == 2 and 'SKIP_ZERORPC' not in os.environ:
         tests_require += ['zerorpc>=0.4.0,<0.5']
     tests_require += ['psycopg2']
 

--- a/test_requirements/requirements-base.txt
+++ b/test_requirements/requirements-base.txt
@@ -33,4 +33,3 @@ requests
 urllib3
 
 pytz
-pyzmq==13.1.0

--- a/test_requirements/requirements-python-2.txt
+++ b/test_requirements/requirements-python-2.txt
@@ -1,4 +1,2 @@
-gevent==1.1b1
-zerorpc>=0.4.0,<0.5
 unittest2
 python-memcached

--- a/test_requirements/requirements-zerorpc.txt
+++ b/test_requirements/requirements-zerorpc.txt
@@ -1,0 +1,3 @@
+pyzmq==13.1.0
+gevent==1.1b1
+zerorpc>=0.4.0,<0.5

--- a/travis/build_manylinux_wheels.sh
+++ b/travis/build_manylinux_wheels.sh
@@ -13,7 +13,7 @@ for PYBIN in /opt/python/*/bin; do
 done
 
 # Bundle external shared libraries into the wheels
-for whl in wheelhouse/*.whl; do
+for whl in wheelhouse/opbeat*.whl; do
     auditwheel repair $whl -w /io/wheelhouse/
 done
 

--- a/travis/build_manylinux_wheels.sh
+++ b/travis/build_manylinux_wheels.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+export SKIP_ZERORPC=1
+export OPBEAT_WRAPT_EXTENSIONS="true"
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    ${PYBIN}/pip install -r /io/test_requirements/requirements-base.txt
+    ${PYBIN}/pip install -r /io/test_requirements/requirements-python-$($PYBIN/python -c "import sys; print(sys.version_info[0])").txt
+    ${PYBIN}/pip wheel /io/ -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*.whl; do
+    auditwheel repair $whl -w /io/wheelhouse/
+done
+
+# Install packages and test
+for PYBIN in /opt/python/*/bin/; do
+    ${PYBIN}/pip install opbeat --no-index -f /io/wheelhouse
+    (cd $HOME; ${PYBIN}/py.test)
+done
+
+chmod 0777 /io/wheelhouse/*.whl

--- a/travis/run_docker.sh
+++ b/travis/run_docker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p wheelhouse
+docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build_manylinux_wheels.sh
+ls wheelhouse/

--- a/travis/run_docker.sh
+++ b/travis/run_docker.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-
-mkdir -p wheelhouse
-docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build_manylinux_wheels.sh
-ls wheelhouse/
+if [ -z ${TRAVIS_TAG+x} ]; then
+  echo "Not a tagged build, skipping building wheels";
+else
+  mkdir -p wheelhouse;
+  docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build_manylinux_wheels.sh;
+  ls wheelhouse/;
+fi

--- a/travis/run_tests.sh
+++ b/travis/run_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+mkdir -p $PIP_CACHE
+psql -c 'create database opbeat_test;' -U postgres
+pip install -U pip
+pip install -r test_requirements/requirements-$WEBFRAMEWORK.txt --cache-dir $PIP_CACHE
+pip install -r test_requirements/requirements-python-$(python -c "import sys; print(sys.version_info[0])").txt --cache-dir $PIP_CACHE
+if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install -r test_requirements/requirements-asyncio.txt --cache-dir $PIP_CACHE; fi
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install -r test_requirements/requirements-cpython.txt --cache-dir $PIP_CACHE; fi
+if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install -r test_requirements/requirements-pypy.txt --cache-dir $PIP_CACHE; fi
+
+make test

--- a/travis/run_tests.sh
+++ b/travis/run_tests.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
+PYTHON_MAJOR_VERSION=$(python -c "import sys; print(sys.version_info[0])");
 mkdir -p $PIP_CACHE
 psql -c 'create database opbeat_test;' -U postgres
 pip install -U pip
-pip install -r test_requirements/requirements-$WEBFRAMEWORK.txt --cache-dir $PIP_CACHE
-pip install -r test_requirements/requirements-python-$(python -c "import sys; print(sys.version_info[0])").txt --cache-dir $PIP_CACHE
-if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install -r test_requirements/requirements-asyncio.txt --cache-dir $PIP_CACHE; fi
-if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install -r test_requirements/requirements-cpython.txt --cache-dir $PIP_CACHE; fi
-if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install -r test_requirements/requirements-pypy.txt --cache-dir $PIP_CACHE; fi
+pip install -r test_requirements/requirements-${WEBFRAMEWORK}.txt --cache-dir ${PIP_CACHE}
+pip install -r test_requirements/requirements-python-${PYTHON_MAJOR_VERSION}.txt --cache-dir ${PIP_CACHE}
+if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then
+  pip install -r test_requirements/requirements-asyncio.txt --cache-dir ${PIP_CACHE};
+fi
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then
+  pip install -r test_requirements/requirements-cpython.txt --cache-dir ${PIP_CACHE};
+  if [[ $PYTHON_MAJOR_VERSION == '2' ]]; then
+    pip install -r test_requirements/requirements-zerorpc.txt --cache-dir ${PIP_CACHE};
+  fi
+fi
+if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then
+  pip install -r test_requirements/requirements-pypy.txt --cache-dir ${PIP_CACHE};
+fi
 
 make test


### PR DESCRIPTION
This allows users on most Linux environments to install Opbeat including
binary dependencies without having to have a compiler installed.

For now, this will just upload the wheels to Github when a commit is
tagged. In the future, we can configure it to automatically upload the
wheels to PyPI.