### PR TITLE
Only listen to Flask signals for the application that is being initialised

### DIFF
--- a/opbeat/contrib/flask/__init__.py
+++ b/opbeat/contrib/flask/__init__.py
@@ -187,8 +187,8 @@ class Opbeat(object):
         else:
             opbeat.instrumentation.control.instrument()
 
-            signals.request_started.connect(self.request_started)
-            signals.request_finished.connect(self.request_finished)
+            signals.request_started.connect(self.request_started, sender=app)
+            signals.request_finished.connect(self.request_finished, sender=app)
 
     def request_started(self, app):
         self.client.begin_transaction("web.flask")


### PR DESCRIPTION
I use application dispatching to combine several Flask applications. Without the sender argument I get performance monitoring data in Opbeat for the applications rather than just the ones that Opbeat is initialised on.