### PR TITLE
Parse README as UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup_kwargs = dict(
     author_email='support@opbeat.com',
     url='https://github.com/opbeat/opbeat_python',
     description='The official Python module for Opbeat.com',
-    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
+    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     packages=find_packages(exclude=("tests",)),
     zip_safe=False,
     install_requires=install_requires,


### PR DESCRIPTION
As the Readme now includes UTF8, we need to enforce encoding for setups where locale are not set to UTF8.

Otherwise, installing gives the following:

    Collecting opbeat
      Using cached opbeat-3.3.2.tar.gz
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 20, in <module>
          File "/tmp/pip-build-q_7mih6e/opbeat/setup.py", line 152, in <module>
            long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
          File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
            return codecs.ascii_decode(input, self.errors)[0]
        UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1459: ordinal not in range(128)

See https://github.com/pypa/sampleproject/blob/master/setup.py for an example.