### PR TITLE
Support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - WEBFRAMEWORK=django-1.7
     - WEBFRAMEWORK=django-1.8
     - WEBFRAMEWORK=django-1.9
+    - WEBFRAMEWORK=django-1.10
     - WEBFRAMEWORK=django-master
     - WEBFRAMEWORK=flask-0.10
   global:
@@ -31,11 +32,15 @@ matrix:
   - python: 2.6
     env: WEBFRAMEWORK=django-1.9
   - python: 2.6
+    env: WEBFRAMEWORK=django-1.10
+  - python: 2.6
     env: WEBFRAMEWORK=django-master
   - python: 3.3
     env: WEBFRAMEWORK=django-1.4
   - python: 3.3
     env: WEBFRAMEWORK=django-1.9
+  - python: 3.3
+    env: WEBFRAMEWORK=django-1.10
   - python: 3.3
     env: WEBFRAMEWORK=django-master
   - python: 3.4

--- a/opbeat/contrib/django/management/commands/opbeat.py
+++ b/opbeat/contrib/django/management/commands/opbeat.py
@@ -117,19 +117,26 @@ class Command(BaseCommand):
 
     # Django 1.8+
     def add_arguments(self, parser):
+        parser.add_argument('subcommand')
         for args, kwargs in self.arguments:
             parser.add_argument(*args, **kwargs)
 
     def handle(self, *args, **options):
-        if not args:
-            self.handle_command_not_found('No command specified.')
-        elif args[0] not in self.dispatch:
-            self.handle_command_not_found('No such command "%s".' % args[0])
+        if 'subcommand' in options:
+            # Django 1.8+, argparse
+            subcommand = options['subcommand']
+        elif not args:
+            return self.handle_command_not_found('No command specified.')
+        else:
+            # Django 1.7, optparse
+            subcommand = args[0]
+        if subcommand not in self.dispatch:
+            self.handle_command_not_found('No such command "%s".' % subcommand)
         else:
             self.dispatch.get(
-                args[0],
+                subcommand,
                 self.handle_command_not_found
-            )(self, args[0], **options)
+            )(self, subcommand, **options)
 
     def handle_test(self, command, **options):
         """Send a test error to Opbeat"""

--- a/test_requirements/requirements-django-1.10.txt
+++ b/test_requirements/requirements-django-1.10.txt
@@ -1,0 +1,2 @@
+Django>=1.10,<1.11
+-r requirements-base.txt


### PR DESCRIPTION
This adds support for Django 1.10. The two main issues were

 * our somewhat hacky way of implementing sub commands for the "opbeat" management command, which stopped working in 1.10
 * The [revised middleware system](https://github.com/django/deps/blob/master/final/0005-improved-middleware.rst) in Django 1.10

The first issue was solved by using proper position arguments with argparse. I also switched to use `call_command` instead of instantiating a command object and calling it directly.

To support new-style middleware, we need to inherit from the new `MiddlewareMixin`. This makes the middleware classes work in both scenarios.

One unfortunate effect of the new middleware system is that we have less insight what is going on inside the middleware. There is no way (AFAICT) to tell if a middleware short-circuits and returns its own `HttpResponse` or if it forwards the response to the next middleware. In the long run (when middleware implementations start dropping the old-style `process_request` and `process_response` methods), this will lead to more transactions not having a name (e.g. responses generated by `APPEND_SLASH` / `PREPEND_WWW` redirects).