### PR TITLE
urllib3 transport

### DIFF
--- a/opbeat/base.py
+++ b/opbeat/base.py
@@ -24,7 +24,7 @@ import zlib
 import opbeat
 from opbeat.conf import defaults
 from opbeat.traces import RequestsStore
-from opbeat.transport.http import AsyncHTTPTransport, HTTPTransport
+from opbeat.transport.http_urllib3 import AsyncUrllib3Transport, Urllib3Transport
 from opbeat.utils import opbeat_json as json
 from opbeat.utils import is_master_process, six, stacks, varmap
 from opbeat.utils.compat import atexit_register, urlparse
@@ -109,7 +109,7 @@ class Client(object):
     >>>     1/0
     >>> except ZeroDivisionError:
     >>>     ident = client.get_ident(client.capture_exception())
-    >>>     print "Exception caught; reference is %%s" %% ident
+    >>>     print ("Exception caught; reference is %%s" %% ident)
     """
     logger = logging.getLogger('opbeat')
     protocol_version = '1.0'
@@ -158,7 +158,7 @@ class Client(object):
             self._transport_class = import_string(transport_class)
         else:
             self._transport_class = (
-                AsyncHTTPTransport if self.async_mode else HTTPTransport
+                AsyncUrllib3Transport if self.async_mode else Urllib3Transport
             )
         self._transports = {}
 
@@ -431,7 +431,7 @@ class Client(object):
             # the danger of being forked into an inconsistent threading state
             self.logger.info('Sending message synchronously while in master '
                              'process. PID: %s', os.getpid())
-            return HTTPTransport(parsed_url)
+            return Urllib3Transport(parsed_url)
         if parsed_url not in self._transports:
             self._transports[parsed_url] = self._transport_class(parsed_url)
         return self._transports[parsed_url]

--- a/opbeat/base.py
+++ b/opbeat/base.py
@@ -24,8 +24,6 @@ import zlib
 import opbeat
 from opbeat.conf import defaults
 from opbeat.traces import RequestsStore
-from opbeat.transport.http_urllib3 import (AsyncUrllib3Transport,
-                                           Urllib3Transport)
 from opbeat.utils import opbeat_json as json
 from opbeat.utils import is_master_process, six, stacks, varmap
 from opbeat.utils.compat import atexit_register, urlparse
@@ -155,12 +153,11 @@ class Client(object):
             async_mode = async
         self.async_mode = (async_mode is True
                            or (defaults.ASYNC_MODE and async_mode is not False))
-        if transport_class:
-            self._transport_class = import_string(transport_class)
-        else:
-            self._transport_class = (
-                AsyncUrllib3Transport if self.async_mode else Urllib3Transport
-            )
+        if not transport_class:
+            transport_class = (defaults.ASYNC_TRANSPORT_CLASS
+                               if self.async_mode
+                               else defaults.SYNC_TRANSPORT_CLASS)
+        self._transport_class = import_string(transport_class)
         self._transports = {}
 
         # servers may be set to a NoneType (for Django)
@@ -432,7 +429,7 @@ class Client(object):
             # the danger of being forked into an inconsistent threading state
             self.logger.info('Sending message synchronously while in master '
                              'process. PID: %s', os.getpid())
-            return Urllib3Transport(parsed_url)
+            return import_string(defaults.SYNC_TRANSPORT_CLASS)(parsed_url)
         if parsed_url not in self._transports:
             self._transports[parsed_url] = self._transport_class(parsed_url)
         return self._transports[parsed_url]

--- a/opbeat/base.py
+++ b/opbeat/base.py
@@ -24,7 +24,8 @@ import zlib
 import opbeat
 from opbeat.conf import defaults
 from opbeat.traces import RequestsStore
-from opbeat.transport.http_urllib3 import AsyncUrllib3Transport, Urllib3Transport
+from opbeat.transport.http_urllib3 import (AsyncUrllib3Transport,
+                                           Urllib3Transport)
 from opbeat.utils import opbeat_json as json
 from opbeat.utils import is_master_process, six, stacks, varmap
 from opbeat.utils.compat import atexit_register, urlparse

--- a/opbeat/conf/defaults.py
+++ b/opbeat/conf/defaults.py
@@ -76,3 +76,7 @@ ASYNC_MODE = True
 
 # Should opbeat wrap middleware for better metrics detection
 INSTRUMENT_DJANGO_MIDDLEWARE = True
+
+SYNC_TRANSPORT_CLASS = 'opbeat.transport.http_urllib3.Urllib3Transport'
+
+ASYNC_TRANSPORT_CLASS = 'opbeat.transport.http_urllib3.AsyncUrllib3Transport'

--- a/opbeat/transport/http_urllib3.py
+++ b/opbeat/transport/http_urllib3.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
+
 import certifi
 import urllib3
 from urllib3.exceptions import MaxRetryError, TimeoutError
-
 
 from opbeat.conf import defaults
 from opbeat.transport.base import TransportException

--- a/opbeat/transport/http_urllib3.py
+++ b/opbeat/transport/http_urllib3.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+import certifi
+import urllib3
+from urllib3.exceptions import MaxRetryError, TimeoutError
+
+
+from opbeat.conf import defaults
+from opbeat.transport.base import TransportException
+from opbeat.transport.http import AsyncHTTPTransport, HTTPTransport
+
+
+ca_certs = certifi.where()
+
+
+class Urllib3Transport(HTTPTransport):
+
+    scheme = ['http', 'https']
+
+    def __init__(self, parsed_url):
+        self.http = urllib3.PoolManager(
+            cert_reqs='CERT_REQUIRED' if ca_certs else 'CERT_NONE',
+            ca_certs=ca_certs,
+        )
+        super(Urllib3Transport, self).__init__(parsed_url)
+
+    def send(self, data, headers, timeout=None):
+        if timeout is None:
+            timeout = defaults.TIMEOUT
+        response = None
+        try:
+            try:
+                response = self.http.urlopen(
+                    'POST', self._url, body=data, headers=headers, timeout=timeout
+                )
+            except Exception as e:
+                print_trace = True
+                if isinstance(e, MaxRetryError) and isinstance(e.reason, TimeoutError):
+                    message = (
+                        "Connection to Opbeat server timed out "
+                        "(url: %s, timeout: %d seconds)" % (self._url, timeout)
+                    )
+                    print_trace = False
+                else:
+                    message = 'Unable to reach Opbeat server: %s (url: %s)' % (
+                        e, self._url
+                    )
+                raise TransportException(message, data, print_trace=print_trace)
+            body = response.read()
+            if response.status >= 400:
+                if response.status == 429:  # rate-limited
+                    message = 'Temporarily rate limited: '
+                    print_trace = False
+                else:
+                    message = 'HTTP %s: ' % response.status
+                    print_trace = True
+                message += body.decode('utf8')
+                raise TransportException(message, data, print_trace=print_trace)
+            return response.getheader('Location')
+        finally:
+            if response:
+                response.close()
+
+
+class AsyncUrllib3Transport(AsyncHTTPTransport, Urllib3Transport):
+    scheme = ['http', 'https']
+    async_mode = True
+
+    def send_sync(self, data=None, headers=None, success_callback=None,
+                  fail_callback=None):
+        try:
+            url = Urllib3Transport.send(self, data, headers)
+            if callable(success_callback):
+                success_callback(url=url)
+        except Exception as e:
+            if callable(fail_callback):
+                fail_callback(exception=e)

--- a/setup.py
+++ b/setup.py
@@ -73,9 +73,9 @@ tests_require = [
     'pytz',
     'redis',
     'requests',
-    'urllib3',
     'jinja2',
     'pytest-benchmark',
+    'urllib3-mock',
 
     # isort
     'apipkg',
@@ -115,7 +115,7 @@ if sys.version_info >= (3, 5):
         'pytest-mock',
     ]
 
-install_requires = []
+install_requires = ['urllib3', 'certifi']
 
 try:
     # For Python >= 2.6

--- a/test_requirements/requirements-base.txt
+++ b/test_requirements/requirements-base.txt
@@ -30,6 +30,6 @@ msgpack-python
 pep8
 redis
 requests
-urllib3
+urllib3-mock
 
 pytz

--- a/test_requirements/requirements-base.txt
+++ b/test_requirements/requirements-base.txt
@@ -9,7 +9,8 @@ isort==4.2.2
 pytest-cache==1.0
 pytest-isort==0.1.0
 
-
+urllib3
+certifi
 Jinja2
 Logbook
 MarkupSafe

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -267,8 +267,8 @@ class ClientTest(TestCase):
             },
         )
 
-    @mock.patch('opbeat.base.Urllib3Transport.send')
-    @mock.patch('opbeat.base.Urllib3Transport.close')
+    @mock.patch('opbeat.transport.http_urllib3.Urllib3Transport.send')
+    @mock.patch('opbeat.transport.http_urllib3.Urllib3Transport.close')
     @mock.patch('opbeat.base.Client._traces_collect')
     def test_client_shutdown_sync(self, mock_traces_collect, mock_close,
                                   mock_send):
@@ -286,7 +286,7 @@ class ClientTest(TestCase):
         self.assertEqual(mock_close.call_count, 1)
         self.assertEqual(mock_traces_collect.call_count, 1)
 
-    @mock.patch('opbeat.base.Urllib3Transport.send')
+    @mock.patch('opbeat.transport.http_urllib3.Urllib3Transport.send')
     @mock.patch('opbeat.base.Client._traces_collect')
     def test_client_shutdown_async(self, mock_traces_collect, mock_send):
         client = Client(

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -140,7 +140,7 @@ class ClientTest(TestCase):
 
         self.assertEqual(client.processors, [])
 
-    @mock.patch('opbeat.transport.http.HTTPTransport.send')
+    @mock.patch('opbeat.transport.http_urllib3.Urllib3Transport.send')
     @mock.patch('opbeat.base.ClientState.should_try')
     def test_send_remote_failover_sync(self, should_try, http_send):
         should_try.return_value = True
@@ -169,7 +169,7 @@ class ClientTest(TestCase):
         client.send_remote('http://example.com/api/store', 'foo')
         assert client.state.status == client.state.ONLINE
 
-    @mock.patch('opbeat.transport.http.HTTPTransport.send')
+    @mock.patch('opbeat.transport.http_urllib3.Urllib3Transport.send')
     @mock.patch('opbeat.base.ClientState.should_try')
     def test_send_remote_failover_async(self, should_try, http_send):
         should_try.return_value = True
@@ -267,8 +267,8 @@ class ClientTest(TestCase):
             },
         )
 
-    @mock.patch('opbeat.base.HTTPTransport.send')
-    @mock.patch('opbeat.base.HTTPTransport.close')
+    @mock.patch('opbeat.base.Urllib3Transport.send')
+    @mock.patch('opbeat.base.Urllib3Transport.close')
     @mock.patch('opbeat.base.Client._traces_collect')
     def test_client_shutdown_sync(self, mock_traces_collect, mock_close,
                                   mock_send):
@@ -286,7 +286,7 @@ class ClientTest(TestCase):
         self.assertEqual(mock_close.call_count, 1)
         self.assertEqual(mock_traces_collect.call_count, 1)
 
-    @mock.patch('opbeat.base.HTTPTransport.send')
+    @mock.patch('opbeat.base.Urllib3Transport.send')
     @mock.patch('opbeat.base.Client._traces_collect')
     def test_client_shutdown_async(self, mock_traces_collect, mock_send):
         client = Client(

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -1253,13 +1253,10 @@ class DjangoManagementCommandTest(TestCase):
         output = stdout.getvalue()
         assert 'not at the first position' in output
 
-    @mock.patch('opbeat.transport.http.urlopen')
+    @mock.patch('opbeat.transport.http_urllib3.urllib3.PoolManager.urlopen')
     def test_test_exception(self, urlopen_mock):
         stdout = six.StringIO()
-        resp = six.moves.urllib.response.addinfo(
-            mock.Mock(),
-            headers={'Location': 'http://example.com'}
-        )
+        resp = mock.Mock(status=200, getheader=lambda h: 'http://example.com')
         urlopen_mock.return_value = resp
         with self.settings(MIDDLEWARE_CLASSES=(
                 'foo',

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -1,12 +1,12 @@
 import mock
 import pytest
+import urllib3.poolmanager
+from urllib3.exceptions import MaxRetryError, TimeoutError
+from urllib3_mock import Responses
 
 from opbeat.transport.base import TransportException
 from opbeat.transport.http_urllib3 import (AsyncUrllib3Transport,
                                            Urllib3Transport)
-import urllib3.poolmanager
-from urllib3.exceptions import MaxRetryError, TimeoutError
-from urllib3_mock import Responses
 
 try:
     import urlparse

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -1,0 +1,58 @@
+from urllib3_mock import Responses
+from urllib3.exceptions import TimeoutError, MaxRetryError
+import pytest
+from opbeat.transport.base import TransportException
+
+try:
+    import urlparse
+except ImportError:
+    from urllib import parse as urlparse
+
+from opbeat.transport.http_urllib3 import Urllib3Transport, AsyncUrllib3Transport
+
+
+responses = Responses('urllib3')
+
+@responses.activate
+def test_send():
+    transport = Urllib3Transport(urlparse.urlparse('http://localhost'))
+    responses.add('POST', '/', status=202,
+                  adding_headers={'Location': 'http://example.com/foo'})
+    url = transport.send('x', {})
+    assert url == 'http://example.com/foo'
+
+
+@responses.activate
+def test_timeout():
+    transport = Urllib3Transport(urlparse.urlparse('http://localhost'))
+    responses.add('POST', '/', status=202,
+                  body=MaxRetryError(None, None, reason=TimeoutError()))
+    with pytest.raises(TransportException) as exc_info:
+        transport.send('x', {})
+    assert 'timeout' in str(exc_info.value)
+
+
+@responses.activate
+def test_http_error():
+    url, status, body = (
+        'http://localhost:9999', 418, 'Nothing'
+    )
+    transport = Urllib3Transport(urlparse.urlparse(url))
+    responses.add('POST', '/', status=status, body=body)
+
+    with pytest.raises(TransportException) as exc_info:
+        transport.send('x', {})
+    for val in (status, body):
+        assert str(val) in str(exc_info.value)
+
+
+@responses.activate
+def test_generic_error():
+    url, status, message, body = (
+        'http://localhost:9999', 418, "I'm a teapot", 'Nothing'
+    )
+    transport = Urllib3Transport(urlparse.urlparse(url))
+    responses.add('POST', '/', status=status, body=Exception('Oopsie'))
+    with pytest.raises(TransportException) as exc_info:
+        transport.send('x', {})
+    assert 'Oopsie' in str(exc_info.value)


### PR DESCRIPTION
This is an import of https://github.com/opbeat/opbeat_python_urllib3, which proofed itself to be more stable and less problematic than the urllib2 based transport. It adds two runtime dependencies, urllib3 and certifi, as well as a test-dependency, urllib3-mock.