### PR TITLE
properly trace paramless `execute` SQL call (#135)

### DIFF
--- a/opbeat/instrumentation/packages/dbapi2.py
+++ b/opbeat/instrumentation/packages/dbapi2.py
@@ -161,11 +161,11 @@ def extract_signature(sql):
 class CursorProxy(wrapt.ObjectProxy):
     provider_name = None
 
-    def callproc(self, procname, params=()):
+    def callproc(self, procname, params=None):
         return self._trace_sql(self.__wrapped__.callproc, procname,
                                params)
 
-    def execute(self, sql, params=()):
+    def execute(self, sql, params=None):
         return self._trace_sql(self.__wrapped__.execute, sql, params)
 
     def executemany(self, sql, param_list):
@@ -176,7 +176,10 @@ class CursorProxy(wrapt.ObjectProxy):
         signature = self.extract_signature(sql)
         kind = "db.{0}.sql".format(self.provider_name)
         with trace(signature, kind, {"sql": sql}):
-            return method(sql, params)
+            if params is None:
+                return method(sql)
+            else:
+                return method(sql, params)
 
     def extract_signature(self, sql):
         raise NotImplementedError()


### PR DESCRIPTION
The Python DB API doesn't seem to work, at least with Django and
Postgres, if you call `execute(sql, ())`. This stack traces trying to
index into the empty param tuple. The signature of the function,
according to PEP 249, is

 .execute ( operation [, parameters ])

so if there are no parameters, execute should be called without that
variable.