### PR TITLE
always return a proxied connection from DbApi2Instrumentation subclasses

### DIFF
--- a/opbeat/instrumentation/packages/dbapi2.py
+++ b/opbeat/instrumentation/packages/dbapi2.py
@@ -194,3 +194,10 @@ class DbApi2Instrumentation(AbstractInstrumentedModule):
 
     def call(self, module, method, wrapped, instance, args, kwargs):
         return ConnectionProxy(wrapped(*args, **kwargs))
+
+    def call_if_sampling(self, module, method, wrapped, instance, args, kwargs):
+        # Contrasting to the superclass implementation, we *always* want to
+        # return a proxied connection, even if there is no ongoing opbeat
+        # transaction yet. This ensures that we instrument the cursor once
+        # the transaction started.
+        return self.call(module, method, wrapped, instance, args, kwargs)


### PR DESCRIPTION
This ensures that we trace SQL queries even if the opbeat transaction
starts after the connection has been created.