### PR TITLE
Django: use request.get_raw_uri to work around DisallowedHost

### DIFF
--- a/opbeat/contrib/django/client.py
+++ b/opbeat/contrib/django/client.py
@@ -119,10 +119,19 @@ class DjangoClient(Client):
 
         environ = request.META
 
+        try:
+            # Django 1.9.
+            get_raw_uri = request.get_raw_uri
+        except AttributeError:
+            # Requires host to be in ALLOWED_HOSTS.
+            url = request.build_absolute_uri()
+        else:
+            url = get_raw_uri()
+
         result = {
             'http': {
                 'method': request.method,
-                'url': request.build_absolute_uri(),
+                'url': url,
                 'query_string': request.META.get('QUERY_STRING'),
                 'data': data,
                 'cookies': dict(request.COOKIES),


### PR DESCRIPTION
Django throws `DisallowedHost` when using
`request.build_absolute_uri()`, where the host is not in the
ALLOWED_HOSTS setting.

This prevents Opbeat then from logging the event properly.

Ref: https://code.djangoproject.com/ticket/27506