### PR TITLE
Handle Spurious FileNotFoundError

### DIFF
--- a/opbeat/utils/__init__.py
+++ b/opbeat/utils/__init__.py
@@ -78,3 +78,5 @@ def is_master_process():
         return os.getpid() == uwsgi.masterpid()
     except ImportError:
         return False
+    except FileNotFoundError:
+        return False


### PR DESCRIPTION
In unusual circumstances (such as https://bugs.python.org/issue22834 in Python versions < 3.5) its possible that import will raise a `FIleNotFoundError` instead of `ImportError`. I've added an additional except clause to catch this edge case. Fixes #153 