### PR TITLE
Botocore instrumentation and improved requests coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ opbeat/utils/wrapt/_wrappers.so
 coverage
 .tox
 .eggs
+.cache
+/testdb.sql
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pip-log.txt
 /example_project/*.db
 opbeat/utils/wrapt/_wrappers.so
 coverage
+.tox
+.eggs

--- a/opbeat/instrumentation/packages/botocore.py
+++ b/opbeat/instrumentation/packages/botocore.py
@@ -1,0 +1,31 @@
+from opbeat.instrumentation.packages.base import AbstractInstrumentedModule
+from opbeat.traces import trace
+from opbeat.utils.compat import urlparse
+
+
+class BotocoreInstrumentation(AbstractInstrumentedModule):
+    name = 'botocore'
+
+    instrument_list = [
+        ('botocore.client', 'BaseClient._make_api_call'),
+    ]
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        if 'operation_name' in kwargs:
+            operation_name = kwargs['operation_name']
+        else:
+            operation_name = args[0]
+
+        target_endpoint = instance._endpoint.host
+        parsed_url = urlparse.urlparse(target_endpoint)
+        service, region, _ = parsed_url.hostname.split('.', 2)
+
+        signature = '{}:{}'.format(service, operation_name)
+        extra_data = {
+            'service': service,
+            'region': region,
+            'operation': operation_name,
+        }
+
+        with trace(signature, 'ext.http.aws', extra_data):
+            return wrapped(*args, **kwargs)

--- a/opbeat/instrumentation/packages/botocore.py
+++ b/opbeat/instrumentation/packages/botocore.py
@@ -27,5 +27,5 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
             'operation': operation_name,
         }
 
-        with trace(signature, 'ext.http.aws', extra_data):
+        with trace(signature, 'ext.http.aws', extra_data, leaf=True):
             return wrapped(*args, **kwargs)

--- a/opbeat/instrumentation/packages/requests.py
+++ b/opbeat/instrumentation/packages/requests.py
@@ -4,51 +4,21 @@ from opbeat.utils import default_ports
 from opbeat.utils.compat import urlparse
 
 
-class HostFromUrlMixin(object):
+def get_host_from_url(url):
+    parsed_url = urlparse.urlparse(url)
+    host = parsed_url.hostname or " "
 
-    def get_host_from_url(self, url):
-        parsed_url = urlparse.urlparse(url)
-        host = parsed_url.hostname or " "
+    if (
+        parsed_url.port and
+        default_ports.get(parsed_url.scheme) != parsed_url.port
+    ):
+        host += ":" + str(parsed_url.port)
 
-        if (
-            parsed_url.port and
-            default_ports.get(parsed_url.scheme) != parsed_url.port
-        ):
-            host += ":" + str(parsed_url.port)
-
-        return host
+    return host
 
 
-class RequestsInstrumentation(AbstractInstrumentedModule, HostFromUrlMixin):
+class RequestsInstrumentation(AbstractInstrumentedModule):
     name = 'requests'
-
-    instrument_list = [
-        ("requests.sessions", "Session.request"),
-    ]
-
-    def call(self, module, method, wrapped, instance, args, kwargs):
-        if 'method' in kwargs:
-            method = kwargs['method']
-        else:
-            method = args[0]
-
-        if 'url' in kwargs:
-            url = kwargs['url']
-        else:
-            url = args[1]
-
-        signature = method.upper()
-
-        if url:
-            signature += " " + self.get_host_from_url(url)
-
-        with trace(signature, "ext.http.requests",
-                   {'url': url}, leaf=True):
-            return wrapped(*args, **kwargs)
-
-
-class PreparedRequestInstrumentation(AbstractInstrumentedModule, HostFromUrlMixin):
-    name = 'requests_prepared_request'
 
     instrument_list = [
         ("requests.sessions", "Session.send"),
@@ -61,7 +31,7 @@ class PreparedRequestInstrumentation(AbstractInstrumentedModule, HostFromUrlMixi
             request = args[0]
 
         signature = request.method.upper()
-        signature += " " + self.get_host_from_url(request.url)
+        signature += " " + get_host_from_url(request.url)
 
         with trace(signature, "ext.http.requests",
                    {'url': request.url}, leaf=True):

--- a/opbeat/instrumentation/packages/requests.py
+++ b/opbeat/instrumentation/packages/requests.py
@@ -4,7 +4,22 @@ from opbeat.utils import default_ports
 from opbeat.utils.compat import urlparse
 
 
-class RequestsInstrumentation(AbstractInstrumentedModule):
+class HostFromUrlMixin(object):
+
+    def get_host_from_url(self, url):
+        parsed_url = urlparse.urlparse(url)
+        host = parsed_url.hostname or " "
+
+        if (
+            parsed_url.port and
+            default_ports.get(parsed_url.scheme) != parsed_url.port
+        ):
+            host += ":" + str(parsed_url.port)
+
+        return host
+
+
+class RequestsInstrumentation(AbstractInstrumentedModule, HostFromUrlMixin):
     name = 'requests'
 
     instrument_list = [
@@ -25,14 +40,29 @@ class RequestsInstrumentation(AbstractInstrumentedModule):
         signature = method.upper()
 
         if url:
-            parsed_url = urlparse.urlparse(url)
-            host = parsed_url.hostname or " "
-            signature += " " + host
-
-            if parsed_url.port and \
-               default_ports.get(parsed_url.scheme) != parsed_url.port:
-                signature += ":" + str(parsed_url.port)
+            signature += " " + self.get_host_from_url(url)
 
         with trace(signature, "ext.http.requests",
                    {'url': url}, leaf=True):
+            return wrapped(*args, **kwargs)
+
+
+class PreparedRequestInstrumentation(AbstractInstrumentedModule, HostFromUrlMixin):
+    name = 'requests_prepared_request'
+
+    instrument_list = [
+        ("requests.sessions", "Session.send"),
+    ]
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        if 'request' in kwargs:
+            request = kwargs['request']
+        else:
+            request = args[0]
+
+        signature = request.method.upper()
+        signature += " " + self.get_host_from_url(request.url)
+
+        with trace(signature, "ext.http.requests",
+                   {'url': request.url}, leaf=True):
             return wrapped(*args, **kwargs)

--- a/opbeat/instrumentation/register.py
+++ b/opbeat/instrumentation/register.py
@@ -14,7 +14,6 @@ _cls_register = set([
     'opbeat.instrumentation.packages.redis.RedisInstrumentation',
     'opbeat.instrumentation.packages.redis.RedisPipelineInstrumentation',
     'opbeat.instrumentation.packages.requests.RequestsInstrumentation',
-    'opbeat.instrumentation.packages.requests.PreparedRequestInstrumentation',
     'opbeat.instrumentation.packages.sqlite.SQLiteInstrumentation',
     'opbeat.instrumentation.packages.urllib3.Urllib3Instrumentation',
 

--- a/opbeat/instrumentation/register.py
+++ b/opbeat/instrumentation/register.py
@@ -14,6 +14,7 @@ _cls_register = set([
     'opbeat.instrumentation.packages.redis.RedisInstrumentation',
     'opbeat.instrumentation.packages.redis.RedisPipelineInstrumentation',
     'opbeat.instrumentation.packages.requests.RequestsInstrumentation',
+    'opbeat.instrumentation.packages.requests.PreparedRequestInstrumentation',
     'opbeat.instrumentation.packages.sqlite.SQLiteInstrumentation',
     'opbeat.instrumentation.packages.urllib3.Urllib3Instrumentation',
 

--- a/opbeat/instrumentation/register.py
+++ b/opbeat/instrumentation/register.py
@@ -1,6 +1,7 @@
 from opbeat.utils.module_import import import_string
 
 _cls_register = set([
+    'opbeat.instrumentation.packages.botocore.BotocoreInstrumentation',
     'opbeat.instrumentation.packages.jinja2.Jinja2Instrumentation',
     'opbeat.instrumentation.packages.psycopg2.Psycopg2Instrumentation',
     'opbeat.instrumentation.packages.psycopg2.Psycopg2RegisterTypeInstrumentation',

--- a/test_requirements/requirements-base.txt
+++ b/test_requirements/requirements-base.txt
@@ -21,6 +21,7 @@ anyjson
 argparse
 billiard
 blinker>=1.1
+boto3
 celery<4
 greenlet
 itsdangerous

--- a/tests/instrumentation/botocore_tests.py
+++ b/tests/instrumentation/botocore_tests.py
@@ -1,0 +1,32 @@
+import boto3
+import mock
+
+import opbeat
+import opbeat.instrumentation.control
+from opbeat.traces import trace
+from tests.helpers import get_tempstoreclient
+from tests.utils.compat import TestCase
+
+
+class InstrumentBotocoreTest(TestCase):
+    def setUp(self):
+        self.client = get_tempstoreclient()
+        opbeat.instrumentation.control.instrument()
+
+    @mock.patch("botocore.endpoint.Endpoint.make_request")
+    def test_botocore_instrumentation(self, mock_make_request):
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_make_request.return_value = (mock_response, {})
+
+        self.client.begin_transaction("transaction.test")
+        with trace("test_pipeline", "test"):
+            session = boto3.Session(aws_access_key_id='foo',
+                                    aws_secret_access_key='bar',
+                                    region_name='us-west-2')
+            ec2 = session.client('ec2')
+            ec2.describe_instances()
+        self.client.end_transaction("MyView")
+
+        _, traces = self.client.instrumentation_store.get_all()
+        self.assertIn('ec2:DescribeInstances', map(lambda x: x['signature'], traces))

--- a/tests/instrumentation/requests_tests.py
+++ b/tests/instrumentation/requests_tests.py
@@ -14,22 +14,40 @@ class InstrumentRequestsTest(TestCase):
         self.client = get_tempstoreclient()
         opbeat.instrumentation.control.instrument()
 
-    @mock.patch("requests.sessions.Session.send")
+    @mock.patch("requests.adapters.HTTPAdapter.send")
     def test_requests_instrumentation(self, _):
         self.client.begin_transaction("transaction.test")
         with trace("test_pipeline", "test"):
-            requests.get('http://example.com')
+            # NOTE: The `allow_redirects` argument has to be set to `False`,
+            # because mocking is done a level deeper, and the mocked response
+            # from the `HTTPAdapter` is about to be used to make further
+            # requests to resolve redirects, which doesn't make sense for this
+            # test case.
+            requests.get('http://example.com', allow_redirects=False)
         self.client.end_transaction("MyView")
 
         _, traces = self.client.instrumentation_store.get_all()
         self.assertIn('GET example.com', map(lambda x: x['signature'], traces))
 
-    @mock.patch("requests.sessions.Session.send")
+    @mock.patch("requests.adapters.HTTPAdapter.send")
     def test_requests_instrumentation_via_session(self, _):
         self.client.begin_transaction("transaction.test")
         with trace("test_pipeline", "test"):
             s = requests.Session()
-            s.get('http://example.com')
+            s.get('http://example.com', allow_redirects=False)
+        self.client.end_transaction("MyView")
+
+        _, traces = self.client.instrumentation_store.get_all()
+        self.assertIn('GET example.com', map(lambda x: x['signature'], traces))
+
+    @mock.patch("requests.adapters.HTTPAdapter.send")
+    def test_requests_instrumentation_via_prepared_request(self, _):
+        self.client.begin_transaction("transaction.test")
+        with trace("test_pipeline", "test"):
+            r = requests.Request('get', 'http://example.com')
+            pr = r.prepare()
+            s = requests.Session()
+            s.send(pr, allow_redirects=False)
         self.client.end_transaction("MyView")
 
         _, traces = self.client.instrumentation_store.get_all()


### PR DESCRIPTION
This patch adds instrumentation for the AWS SDK (`boto3`/`botocore`), and improves the coverage of `requests` instrumentation in order to pick up `PreparedRequests` sent directly on a lower level.

This patch improved the coverage of our performance report significantly.