### PR TITLE
tests: celery 4 by default; handle django-celery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ tests_require = [
     'pytest-capturelog>=0.7',
     'blinker>=1.1',
     'celery',
-    'django-celery',
     'Flask>=0.8',
     'logbook',
     'mock',

--- a/test_requirements/requirements-base.txt
+++ b/test_requirements/requirements-base.txt
@@ -22,7 +22,7 @@ argparse
 billiard
 blinker>=1.1
 boto3
-celery<4
+celery
 greenlet
 itsdangerous
 kombu<4

--- a/test_requirements/requirements-django-1.10.txt
+++ b/test_requirements/requirements-django-1.10.txt
@@ -1,3 +1,2 @@
 Django>=1.10,<1.11
-django-celery
 -r requirements-base.txt

--- a/test_requirements/requirements-django-1.11.txt
+++ b/test_requirements/requirements-django-1.11.txt
@@ -1,3 +1,2 @@
 Django>=1.11b1,<1.12
-django-celery
 -r requirements-base.txt

--- a/test_requirements/requirements-django-1.4.txt
+++ b/test_requirements/requirements-django-1.4.txt
@@ -1,3 +1,4 @@
 Django>=1.4.21,<1.5
+celery<4
 django-celery
 -r requirements-base.txt

--- a/test_requirements/requirements-django-1.5.txt
+++ b/test_requirements/requirements-django-1.5.txt
@@ -1,3 +1,4 @@
 Django>=1.5.12,<1.6
+celery<4
 django-celery
 -r requirements-base.txt

--- a/test_requirements/requirements-django-1.6.txt
+++ b/test_requirements/requirements-django-1.6.txt
@@ -1,3 +1,4 @@
 Django>=1.6.11,<1.7
+celery<4
 django-celery
 -r requirements-base.txt

--- a/test_requirements/requirements-django-1.7.txt
+++ b/test_requirements/requirements-django-1.7.txt
@@ -1,3 +1,4 @@
 Django>=1.7.9,<1.8
+celery<4
 django-celery
 -r requirements-base.txt

--- a/test_requirements/requirements-django-1.8.txt
+++ b/test_requirements/requirements-django-1.8.txt
@@ -1,3 +1,2 @@
 Django>=1.8.3,<1.9
-django-celery
 -r requirements-base.txt

--- a/test_requirements/requirements-django-1.9.txt
+++ b/test_requirements/requirements-django-1.9.txt
@@ -1,3 +1,2 @@
 Django>=1.9,<1.10
-django-celery
 -r requirements-base.txt

--- a/test_requirements/requirements-django-master.txt
+++ b/test_requirements/requirements-django-master.txt
@@ -1,3 +1,2 @@
 -e git://github.com/django/django.git@master#egg=Django
-django-celery
 -r requirements-base.txt


### PR DESCRIPTION
Only install django-celery for Django versions where it is actually
used.  This also requires to use Celery<4 there then [1].

1: https://github.com/celery/django-celery/commit/4ed4067e94e141a37baa7b085906766fb162d676.