### PR TITLE
Don't use is_authenticated as a method

### DIFF
--- a/opbeat/contrib/django/client.py
+++ b/opbeat/contrib/django/client.py
@@ -65,7 +65,7 @@ class DjangoClient(Client):
 
     def get_user_info(self, request):
         try:
-            if request.user.is_authenticated():
+            if request.user.is_authenticated:
                 user_info = {
                     'is_authenticated': True,
                     'id': request.user.pk,


### PR DESCRIPTION
Since Django 1.11 `is_authenticated` is a property and it's not callable, in previous versions both ways were correct callable and not callable.
