### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
 - 2.7
-- 3.3
 - 3.4
 - 3.5
 - 3.6
@@ -29,16 +28,6 @@ env:
 matrix:
   exclude:
   - python: 2.7
-    env: WEBFRAMEWORK=django-master
-  - python: 3.3
-    env: WEBFRAMEWORK=django-1.4
-  - python: 3.3
-    env: WEBFRAMEWORK=django-1.9
-  - python: 3.3
-    env: WEBFRAMEWORK=django-1.10
-  - python: 3.3
-    env: WEBFRAMEWORK=django-1.11
-  - python: 3.3
     env: WEBFRAMEWORK=django-master
   - python: 3.4
     env: WEBFRAMEWORK=django-1.4

--- a/setup.py
+++ b/setup.py
@@ -174,8 +174,9 @@ setup_kwargs = dict(
         'Topic :: Software Development',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{26,27,33,34,35,py}
+envlist = py{27,34,35,36,py}
 
 [testenv]
 commands = python setup.py test -a "{posargs}"


### PR DESCRIPTION
Reached its EOL in September 2017: https://www.python.org/dev/peps/pep-0398/#x-end-of-life