### PR TITLE
fix Django 2.0 incompatibilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - WEBFRAMEWORK=django-1.9
     - WEBFRAMEWORK=django-1.10
     - WEBFRAMEWORK=django-1.11
+    - WEBFRAMEWORK=django-2.0
     - WEBFRAMEWORK=django-master
     - WEBFRAMEWORK=flask-0.10
     - WEBFRAMEWORK=flask-0.11
@@ -28,6 +29,8 @@ env:
   - RUN_SCRIPT="./travis/run_tests.sh"
 matrix:
   exclude:
+  - python: 2.7
+    env: WEBFRAMEWORK=django-2.0
   - python: 2.7
     env: WEBFRAMEWORK=django-master
   - python: 3.3
@@ -39,9 +42,13 @@ matrix:
   - python: 3.3
     env: WEBFRAMEWORK=django-1.11
   - python: 3.3
+    env: WEBFRAMEWORK=django-2.0
+  - python: 3.3
     env: WEBFRAMEWORK=django-master
   - python: 3.4
     env: WEBFRAMEWORK=django-1.4
+  - python: 3.4
+    env: WEBFRAMEWORK=django-master
   - python: 3.5
     env: WEBFRAMEWORK=django-1.4
   - python: 3.5
@@ -58,6 +65,10 @@ matrix:
     env: WEBFRAMEWORK=django-1.6
   - python: 3.6
     env: WEBFRAMEWORK=django-1.7
+  - python: pypy
+    env: WEBFRAMEWORK=django-2.0
+  - python: pypy
+    env: WEBFRAMEWORK=django-master
   - python: nightly
     env: WEBFRAMEWORK=django-1.4
   - python: nightly

--- a/conftest.py
+++ b/conftest.py
@@ -28,12 +28,17 @@ def pytest_configure(config):
     if settings is not None and not settings.configured:
         import django
 
+        if django.VERSION >= (2, 0):
+            middleware_settings_name = 'MIDDLEWARE'
+        else:
+            middleware_settings_name = 'MIDDLEWARE_CLASSES'
+
         # django-celery does not work well with Django 1.8+
         if django.VERSION < (1, 8):
             djcelery = ['djcelery']
         else:
             djcelery = []
-        settings.configure(
+        settings_dict = dict(
             DATABASES={
                 'default': {
                     'ENGINE': 'django.db.backends.sqlite3',
@@ -91,6 +96,12 @@ def pytest_configure(config):
             ]
 
         )
+        settings_dict[middleware_settings_name] = [
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+        ]
+        settings.configure(**settings_dict)
         if hasattr(django, 'setup'):
             django.setup()
         if django.VERSION < (1, 8):

--- a/opbeat/contrib/django/middleware/__init__.py
+++ b/opbeat/contrib/django/middleware/__init__.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 import logging
 import threading
 
+import django
 from django.conf import settings as django_settings
 
 from opbeat.contrib.django.models import client, get_client
@@ -32,6 +33,11 @@ except ImportError:
     class MiddlewareMixin(object):
         pass
 
+
+if django.VERSION >= (2, 0):
+    middleware_settings_name = 'MIDDLEWARE'
+else:
+    middleware_settings_name = 'MIDDLEWARE_CLASSES'
 
 def _is_ignorable_404(uri):
     """
@@ -122,8 +128,8 @@ class OpbeatAPMMiddleware(MiddlewareMixin):
                     OpbeatAPMMiddleware._opbeat_instrumented = True
 
     def instrument_middlewares(self):
-        if getattr(django_settings, 'MIDDLEWARE_CLASSES', None):
-            for middleware_path in django_settings.MIDDLEWARE_CLASSES:
+        if getattr(django_settings, middleware_settings_name, None):
+            for middleware_path in getattr(django_settings, middleware_settings_name):
                 module_path, class_name = middleware_path.rsplit('.', 1)
                 try:
                     module = import_module(module_path)

--- a/test_requirements/requirements-base.txt
+++ b/test_requirements/requirements-base.txt
@@ -1,5 +1,5 @@
 py==1.4.30
-pytest==2.8.0
+pytest==3.0.6
 pytest-capturelog==0.7
 pytest-django==2.8.0
 pytest-benchmark==2.5.0

--- a/test_requirements/requirements-django-2.0.txt
+++ b/test_requirements/requirements-django-2.0.txt
@@ -1,0 +1,3 @@
+Django>=2.0,<2.1
+django-celery
+-r requirements-base.txt

--- a/tests/contrib/django/testapp/middleware.py
+++ b/tests/contrib/django/testapp/middleware.py
@@ -1,19 +1,27 @@
-class BrokenRequestMiddleware(object):
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # no-op class for Django < 1.10
+    class MiddlewareMixin(object):
+        pass
+
+
+class BrokenRequestMiddleware(MiddlewareMixin):
     def process_request(self, request):
         raise ImportError('request')
 
 
-class BrokenResponseMiddleware(object):
+class BrokenResponseMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         raise ImportError('response')
 
 
-class BrokenViewMiddleware(object):
+class BrokenViewMiddleware(MiddlewareMixin):
     def process_view(self, request, func, args, kwargs):
         raise ImportError('view')
 
 
-class MetricsNameOverrideMiddleware(object):
+class MetricsNameOverrideMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         request._opbeat_transaction_name = 'foobar'
         return response


### PR DESCRIPTION
This fixes all known Django 2.0 incompatibilities. It mostly affected our test suite due to `MIDDLEWARE_CLASSES` being gone.