### PR TITLE
Add Py 3.5 and 3.6 trove classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,6 +176,8 @@ setup_kwargs = dict(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )
 


### PR DESCRIPTION
So that it's reflected on the badge in the README