### PR TITLE
Handle RawPostDataException and salvage POST data

### DIFF
--- a/opbeat/contrib/django/client.py
+++ b/opbeat/contrib/django/client.py
@@ -106,15 +106,24 @@ class DjangoClient(Client):
 
         if request.method != 'GET':
             try:
-                if hasattr(request, 'body'):
-                    # Django 1.4+
-                    raw_data = request.body
+                if hasattr(request, 'raw_post_body'):
+                    # Django <1.4
+                    raw_data = request.raw_post_body
                 else:
-                    raw_data = request.raw_post_data
+                    raw_data = request.body
                 data = raw_data if raw_data else request.POST
-            except Exception:
+            except Exception as e:
                 # assume we had a partial read:
                 data = '<unavailable>'
+
+                try:
+                    # Django 1.4+
+                    from django.http.request import RawPostDataException
+                    
+                    if isinstance(e, RawPostDataException):
+                        data = request.POST.urlencode() or '<unavailable>'
+                except ImportError:
+                    pass
         else:
             data = None
 


### PR DESCRIPTION
Currently Opbeat does a poor job of handling cases where `request.body` has already been read by the time an exception occurs, resulting in POST data of `<unavailable>` a large percentage of the time. If the exception `RawPostDataException` is thrown it means that the request body has already been read and possibly parsed into `request.POST`, which means we can salvage body data from `request.POST`.

This is only a way to salvage form data, data like JSON is unfortunately still lost due to `request.body` being a stream so once the app code has read it there's no way for Opbeat to recover it.